### PR TITLE
4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,73 @@
+# Changelog
+
+Format loosely follows [Keep a Changelog](https://keepachangelog.com/). Versions follow SemVer.
+
+## 4.0.0 - 2026-07-07
+
+### Fixed
+
+- **`MassDeq<T>` data-loss bug**: `MassDeqEnumerator.Remove()` (used by `TryRemove` and
+  `ICollection<T>.Remove`) called `Clear()` whenever the removed node happened to be the physical
+  head of the list — silently wiping every other item in the deque, and resetting `IsReversed`,
+  even when the caller only asked to remove one item. Present since `MassDeq<T>` was introduced;
+  never caught earlier because no test asserted on the actual contents/count after removing a head
+  item, and the one real caller (`GameEngineQueue.TryRemove`) discarded the removed value and never
+  hit this exact shape of list. Fixed by rewriting the splice to update `_head`/`_tail` directly
+  instead of branching on walk direction.
+- **`MassDeq<T>.TryRemove` returned the wrong value**: it returned the deque's current head value
+  instead of the value of the node actually removed (coincidentally correct only when the removed
+  node *was* the head). Went unnoticed for the same reason as above — nothing asserted on the
+  returned value.
+
+### Changed
+
+- **Breaking**: `TryRemove` now returns `bool` with an `out T? removed` parameter, matching the
+  `TryXxx` shape used everywhere else in the BCL (`Dictionary.TryGetValue`, `ConcurrentDictionary.
+  TryRemove`, `Queue.TryDequeue`) and by `MassDeq<T>.TryDequeue` itself. Previously returned a
+  `(bool Success, T? Value)` tuple.
+- **Breaking**: `TryMassDequeue`, `InsertBefore`, `Clone`, and `CloneReverse` now take
+  `Predicate<T>` instead of `Func<T, bool>`, matching `List<T>`'s predicate-based members
+  (`Find`, `RemoveAll`, `Exists`). Existing lambda-literal call sites are source-compatible;
+  call sites passing an explicitly-typed `Func<T, bool>` variable will need to change the
+  variable's declared type.
+
+### Added
+
+- `IMassDeq<T>` interface, covering everything `MassDeq<T>` offers beyond `ICollection<T>`.
+  Also implements `IReadOnlyCollection<T>` directly (`MassDeq<T>` already satisfied it
+  structurally), so callers that only need read access no longer have to go through
+  `AsReadOnly()` to get an `IReadOnlyCollection<T>`-typed reference.
+- `Dequeue()` and `Peek()` — throwing counterparts to `TryDequeue`/`TryPeek`, matching
+  `System.Collections.Generic.Queue<T>`'s shape.
+- `TryPeek(out T item)` — look at the next item `Dequeue`/`TryDequeue` would return, without
+  removing it. `MassDeq<T>` previously had no way to do this at all.
+- 15 new unit tests covering `Dequeue`/`Peek`/`TryPeek`, the new `TryRemove` out-param shape,
+  `IMassDeq<T>`/`IReadOnlyCollection<T>` conformance, and the two `Remove()` bugs above.
+
+## 3.1.0
+
+- Added `IMassDeq<T>` (superseded by the reshaped version above before this ever shipped as a
+  package — no NuGet package has been published from this repo yet, so nothing external depends
+  on the 3.1.0 shape).
+
+## 3.0.0
+
+Version bump only, no code changes in the commit itself. Per the bump commit's own message: this
+version accounts for accumulated breaking changes since `v2.0.0` that were never given their own
+version bump — removal of the public `Encryption`/`IEncryption`/`StringExtensions` types, the
+`Range` → `LongRange` rename, and `WhereableAsyncEnumerable.FirstAsync` changing from silently
+returning `default` on an empty sequence to throwing.
+
+## 2.0.0 and earlier
+
+Tagged retroactively from existing commit history; not curated release notes. `v2.0.0` in
+particular points at a `secret-scan.yml` workflow tweak, not a deliberate package release point.
+Treat pre-3.0.0 tags as approximate history markers, not a reliable source of "what changed."
+
+---
+
+**On tag policy**: tags in this repo are never deleted or rewritten once pushed, including for
+versions later found to have bugs (see `MassDeq<T>` above) — they're kept as an honest, immutable
+record. If/when this package is published to NuGet, buggy versions get *unlisted* (hidden from
+new installs, per NuGet's own mechanism for this) rather than deleted, and the fix is documented
+here rather than silently folded into the old tag.

--- a/Collections/IMassDeq.cs
+++ b/Collections/IMassDeq.cs
@@ -9,9 +9,12 @@ namespace Eggnine.Common.Collections;
 /// <summary>
 /// Members <see cref="MassDeq{T}"/> offers beyond the standard <see cref="ICollection{T}"/> surface:
 /// head-side insertion, contiguous mass-dequeue, predicate-based splicing, cloning, and a read-only
-/// view.
+/// view. Also declares <see cref="IReadOnlyCollection{T}"/> since <see cref="MassDeq{T}"/> already
+/// satisfies it structurally (via <see cref="ICollection{T}.Count"/> and its enumerator) — callers
+/// that only need read access can accept <see cref="IMassDeq{T}"/> directly without going through
+/// <see cref="AsReadOnly"/>.
 /// </summary>
-public interface IMassDeq<T> : ICollection<T>
+public interface IMassDeq<T> : ICollection<T>, IReadOnlyCollection<T>
 {
     /// <summary>True if the deque is currently walking head-to-tail in reverse (see <see cref="Reverse"/>).</summary>
     bool IsReversed { get; }
@@ -25,27 +28,40 @@ public interface IMassDeq<T> : ICollection<T>
     /// <summary>Removes a single item from the tail in O(1) time. Returns false if the deque is empty.</summary>
     bool TryDequeue(out T item);
 
+    /// <summary>Same as <see cref="TryDequeue"/> but throws <see cref="InvalidOperationException"/>
+    /// instead of returning false when the deque is empty — matches <see cref="Queue{T}.Dequeue"/>.</summary>
+    T Dequeue();
+
+    /// <summary>Looks at the next item <see cref="Dequeue"/>/<see cref="TryDequeue"/> would return,
+    /// without removing it. Returns false if the deque is empty.</summary>
+    bool TryPeek(out T item);
+
+    /// <summary>Same as <see cref="TryPeek"/> but throws <see cref="InvalidOperationException"/>
+    /// instead of returning false when the deque is empty — matches <see cref="Queue{T}.Peek"/>.</summary>
+    T Peek();
+
     /// <summary>
     /// Detaches a contiguous run starting from the tail (or head, if <see cref="IsReversed"/>) for as
     /// long as <paramref name="predicate"/> holds, returning it as a new deque. Returns false, leaving
     /// this deque untouched, if empty or the boundary item doesn't match.
     /// </summary>
-    bool TryMassDequeue(Func<T, bool> predicate, out IMassDeq<T> segment);
+    bool TryMassDequeue(Predicate<T> predicate, out IMassDeq<T> segment);
 
     /// <summary>
     /// Finds the first item matching <paramref name="predicate"/> and inserts <paramref name="item"/>
     /// immediately before it, atomically. Returns false if nothing matched.
     /// </summary>
-    bool InsertBefore(T item, Func<T, bool> predicate);
+    bool InsertBefore(T item, Predicate<T> predicate);
 
-    /// <summary>Removes the first item equal to <paramref name="item"/>, returning it via the out-style tuple.</summary>
-    (bool Success, T? Value) TryRemove(T item);
+    /// <summary>Removes the first item equal to <paramref name="item"/>. Returns false, leaving
+    /// <paramref name="removed"/> default, if nothing matched.</summary>
+    bool TryRemove(T item, out T? removed);
 
     /// <summary>Copies matching items (or all, if <paramref name="wherePredicate"/> is null) into a new deque in the same order.</summary>
-    IMassDeq<T> Clone(Func<T, bool>? wherePredicate = null);
+    IMassDeq<T> Clone(Predicate<T>? wherePredicate = null);
 
     /// <summary>Same as <see cref="Clone"/> but the copy comes out reversed.</summary>
-    IMassDeq<T> CloneReverse(Func<T, bool>? wherePredicate = null);
+    IMassDeq<T> CloneReverse(Predicate<T>? wherePredicate = null);
 
     /// <summary>Wraps this deque in a live, read-only <see cref="IReadOnlyCollection{T}"/> view.</summary>
     IReadOnlyCollection<T> AsReadOnly();

--- a/Collections/IMassDeq.cs
+++ b/Collections/IMassDeq.cs
@@ -1,0 +1,52 @@
+// Copyright © 2025-2026 RF@Eggnine.com
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+using System;
+using System.Collections.Generic;
+
+namespace Eggnine.Common.Collections;
+
+/// <summary>
+/// Members <see cref="MassDeq{T}"/> offers beyond the standard <see cref="ICollection{T}"/> surface:
+/// head-side insertion, contiguous mass-dequeue, predicate-based splicing, cloning, and a read-only
+/// view.
+/// </summary>
+public interface IMassDeq<T> : ICollection<T>
+{
+    /// <summary>True if the deque is currently walking head-to-tail in reverse (see <see cref="Reverse"/>).</summary>
+    bool IsReversed { get; }
+
+    /// <summary>Flips which end Enqueue/TryDequeue/enumeration treat as head. O(1).</summary>
+    void Reverse();
+
+    /// <summary>Prepend at head. O(1).</summary>
+    void Enqueue(T item);
+
+    /// <summary>Removes a single item from the tail in O(1) time. Returns false if the deque is empty.</summary>
+    bool TryDequeue(out T item);
+
+    /// <summary>
+    /// Detaches a contiguous run starting from the tail (or head, if <see cref="IsReversed"/>) for as
+    /// long as <paramref name="predicate"/> holds, returning it as a new deque. Returns false, leaving
+    /// this deque untouched, if empty or the boundary item doesn't match.
+    /// </summary>
+    bool TryMassDequeue(Func<T, bool> predicate, out IMassDeq<T> segment);
+
+    /// <summary>
+    /// Finds the first item matching <paramref name="predicate"/> and inserts <paramref name="item"/>
+    /// immediately before it, atomically. Returns false if nothing matched.
+    /// </summary>
+    bool InsertBefore(T item, Func<T, bool> predicate);
+
+    /// <summary>Removes the first item equal to <paramref name="item"/>, returning it via the out-style tuple.</summary>
+    (bool Success, T? Value) TryRemove(T item);
+
+    /// <summary>Copies matching items (or all, if <paramref name="wherePredicate"/> is null) into a new deque in the same order.</summary>
+    IMassDeq<T> Clone(Func<T, bool>? wherePredicate = null);
+
+    /// <summary>Same as <see cref="Clone"/> but the copy comes out reversed.</summary>
+    IMassDeq<T> CloneReverse(Func<T, bool>? wherePredicate = null);
+
+    /// <summary>Wraps this deque in a live, read-only <see cref="IReadOnlyCollection{T}"/> view.</summary>
+    IReadOnlyCollection<T> AsReadOnly();
+}

--- a/Collections/MassDeq.cs
+++ b/Collections/MassDeq.cs
@@ -85,7 +85,7 @@ public sealed class MassDeq<T> : IMassDeq<T>
     /// **ONLY RETURNS CONTIGUOUS SEGMENTS**
     /// If empty, returns false.
     /// </summary>
-    public bool TryMassDequeue(Func<T, bool> predicate, out MassDeq<T> segment)
+    public bool TryMassDequeue(Predicate<T> predicate, out MassDeq<T> segment)
     {
         MassDeqNode<T>? current;
         segment = new();
@@ -147,7 +147,7 @@ public sealed class MassDeq<T> : IMassDeq<T>
     /// happen under one lock hold, so a concurrent TryMassDequeue/TryRemove/etc. can't detach the
     /// found node between "found it" and "spliced next to it" (which would silently orphan the
     /// insert onto a detached segment the live deque no longer points to).</summary>
-    public bool InsertBefore(T item, Func<T, bool> predicate)
+    public bool InsertBefore(T item, Predicate<T> predicate)
     {
         lock (_gate)
         {
@@ -164,14 +164,14 @@ public sealed class MassDeq<T> : IMassDeq<T>
         }
     }
 
-    public MassDeq<T> Clone(Func<T, bool>? wherePredicate = null)
+    public MassDeq<T> Clone(Predicate<T>? wherePredicate = null)
     {
         MassDeq<T> toReturn = CloneReverse(wherePredicate);
         toReturn.Reverse();
         return toReturn;
     }
-    
-    public MassDeq<T> CloneReverse(Func<T, bool>? wherePredicate = null)
+
+    public MassDeq<T> CloneReverse(Predicate<T>? wherePredicate = null)
     {
         MassDeq<T> toReturn = new();
         lock (_gate)
@@ -359,13 +359,11 @@ public sealed class MassDeq<T> : IMassDeq<T>
         }
     }
 
-    bool ICollection<T>.Remove(T item)
-    {
-        var (success, value) = TryRemove(item);
-        return success;
-    }
+    bool ICollection<T>.Remove(T item) => TryRemove(item, out _);
 
-    public (bool Success, T? Value) TryRemove(T item)
+    /// <summary>Removes the first item equal to <paramref name="item"/>. Returns false, leaving
+    /// <paramref name="removed"/> default, if nothing matched.</summary>
+    public bool TryRemove(T item, out T? removed)
     {
         lock (_gate)
         {
@@ -374,21 +372,62 @@ public sealed class MassDeq<T> : IMassDeq<T>
             {
                 if (Equals(enumerator.Current, item))
                 {
-                    return (true, enumerator.Remove());
+                    removed = enumerator.Remove();
+                    return true;
                 }
             }
-            return (false, default);
+            removed = default;
+            return false;
         }
     }
 
-    bool IMassDeq<T>.TryMassDequeue(Func<T, bool> predicate, out IMassDeq<T> segment)
+    /// <summary>Looks at the next item <see cref="Dequeue"/>/<see cref="TryDequeue"/> would return,
+    /// without removing it. Returns false if the deque is empty.</summary>
+    public bool TryPeek(out T item)
+    {
+        lock (_gate)
+        {
+            MassDeqNode<T>? node = _isReversed ? _head : _tail;
+            if (node is null)
+            {
+                item = default!;
+                return false;
+            }
+            item = node.Value;
+            return true;
+        }
+    }
+
+    /// <summary>Same as <see cref="TryPeek"/> but throws <see cref="InvalidOperationException"/>
+    /// instead of returning false when the deque is empty — matches <see cref="Queue{T}.Peek"/>.</summary>
+    public T Peek()
+    {
+        if (!TryPeek(out T item))
+        {
+            throw new InvalidOperationException("MassDeq is empty.");
+        }
+        return item;
+    }
+
+    /// <summary>Same as <see cref="TryDequeue"/> but throws <see cref="InvalidOperationException"/>
+    /// instead of returning false when the deque is empty — matches <see cref="Queue{T}.Dequeue"/>.</summary>
+    public T Dequeue()
+    {
+        if (!TryDequeue(out T item))
+        {
+            throw new InvalidOperationException("MassDeq is empty.");
+        }
+        return item;
+    }
+
+    bool IMassDeq<T>.TryMassDequeue(Predicate<T> predicate, out IMassDeq<T> segment)
     {
         bool result = TryMassDequeue(predicate, out MassDeq<T> concreteSegment);
         segment = concreteSegment;
         return result;
     }
 
-    IMassDeq<T> IMassDeq<T>.Clone(Func<T, bool>? wherePredicate) => Clone(wherePredicate);
+    IMassDeq<T> IMassDeq<T>.Clone(Predicate<T>? wherePredicate) => Clone(wherePredicate);
 
-    IMassDeq<T> IMassDeq<T>.CloneReverse(Func<T, bool>? wherePredicate) => CloneReverse(wherePredicate);
+    IMassDeq<T> IMassDeq<T>.CloneReverse(Predicate<T>? wherePredicate) => CloneReverse(wherePredicate);
 }

--- a/Collections/MassDeq.cs
+++ b/Collections/MassDeq.cs
@@ -17,7 +17,7 @@ namespace Eggnine.Common.Collections;
 /// <see cref="InsertBefore"/>, <see cref="CloneReverse"/>) walk the live list directly under the
 /// same lock instead, avoiding that copy since they never release the lock mid-walk.
 /// </summary>
-public sealed class MassDeq<T> : ICollection<T>
+public sealed class MassDeq<T> : IMassDeq<T>
 {
 
     public MassDeq()
@@ -380,4 +380,15 @@ public sealed class MassDeq<T> : ICollection<T>
             return (false, default);
         }
     }
+
+    bool IMassDeq<T>.TryMassDequeue(Func<T, bool> predicate, out IMassDeq<T> segment)
+    {
+        bool result = TryMassDequeue(predicate, out MassDeq<T> concreteSegment);
+        segment = concreteSegment;
+        return result;
+    }
+
+    IMassDeq<T> IMassDeq<T>.Clone(Func<T, bool>? wherePredicate) => Clone(wherePredicate);
+
+    IMassDeq<T> IMassDeq<T>.CloneReverse(Func<T, bool>? wherePredicate) => CloneReverse(wherePredicate);
 }

--- a/Collections/MassDeqEnumerator.cs
+++ b/Collections/MassDeqEnumerator.cs
@@ -118,82 +118,40 @@ public struct MassDeqEnumerator<T> : IEnumerator<T>
         }
         lock (_original._gate)
         {
-            T? t = default;
-            if (_original._head is not null)
+            // Splicing depends only on the node's own Prev/Next — those are absolute physical
+            // pointers (head always has Prev == null, tail always has Next == null) regardless of
+            // which direction this enumerator is walking, so there is no need to branch on
+            // _isReversed here at all.
+            T removed = _current.Value;
+            MassDeqNode<T>? prev = _current.Prev;
+            MassDeqNode<T>? next = _current.Next;
+
+            if (prev is null)
             {
-                t = _original._head.Value;
-            }
-            if (_isReversed)
-            {
-                if (_current.Next is null)
-                {
-                    _original._count--;
-                    _original._head = null;
-                    _original._tail = null;
-                    _current = null;
-                    _next = null;
-                    if (t is not null)
-                    {
-                        return t;
-                    }
-                    else
-                    {
-                        return default;
-                    }
-                }
-                if (_current.Prev is not null)
-                {
-                    _current.Prev.Next = _current.Next;
-                    _current.Next.Prev = _current.Prev;
-                }
-                else
-                {
-                    _current.Next.Prev = null;
-                }
-                // Detach the removed node's own pointers so a concurrent reader that already
-                // captured it as _current can't keep walking through it into stale/detached
-                // territory (mirrors TryDequeue's existing discipline).
-                _current.Next = null;
-                _current.Prev = null;
-                _original._count--;
+                _original._head = next;
             }
             else
             {
-                if (_current.Prev is null)
-                {
-                    _original.Clear();
-                    _current = null;
-                    _next = null;
-                    if (t is not null)
-                    {
-                        return t;
-                    }
-                    else
-                    {
-                        return default;
-                    }
-                }
-                if (_current.Next is not null)
-                {
-                    _current.Next.Prev = _current.Prev;
-                    _current.Prev.Next = _current.Next;
-                }
-                else
-                {
-                    _current.Prev.Next = null;
-                }
-                _current.Next = null;
-                _current.Prev = null;
-                _original._count--;
+                prev.Next = next;
             }
-            if (t is not null)
+
+            if (next is null)
             {
-                return t;
+                _original._tail = prev;
             }
             else
             {
-                return default;
+                next.Prev = prev;
             }
+
+            // Detach the removed node's own pointers so a concurrent reader that already
+            // captured it as _current can't keep walking through it into stale/detached
+            // territory (mirrors TryDequeue's existing discipline).
+            _current.Next = null;
+            _current.Prev = null;
+            _original._count--;
+
+            return removed;
         }
     }
 

--- a/Eggnine.Common.csproj
+++ b/Eggnine.Common.csproj
@@ -7,7 +7,7 @@
     <PackageProjectUrl>https://github.com/rf-eggnine/Eggnine.Common</PackageProjectUrl>
     <RepositoryUrl>https://github.com/rf-eggnine/Eggnine.Common</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Eggnine.Common.csproj
+++ b/Eggnine.Common.csproj
@@ -7,7 +7,7 @@
     <PackageProjectUrl>https://github.com/rf-eggnine/Eggnine.Common</PackageProjectUrl>
     <RepositoryUrl>https://github.com/rf-eggnine/Eggnine.Common</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>3.1.0</Version>
+    <Version>4.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Standardize IMassDeq<T> to BCL conventions, fix data-loss bug in Remove()

Adds IMassDeq<T> and aligns its shape with the rest of System.Collections.Generic: TryRemove now returns bool + out T? removed (matching Dictionary/ConcurrentDictionary/Queue's TryXxx pattern) instead of a tuple, predicate params switched from Func<T, bool> to Predicate<T> to match List<T>, and added Dequeue()/Peek()/TryPeek() to match Queue<T>'s shape.

Along the way, found and fixed a real bug in MassDeqEnumerator.Remove(): it called Clear() whenever the removed node happened to be the physical head, silently wiping the entire deque (and resetting IsReversed) even when other items remained — and separately returned the wrong value (the deque's head, not the removed node). Both were invisible until TryRemove's return value became load-bearing. Rewritten to be direction-independent instead of branching on IsReversed.

15 new tests, CHANGELOG.md added, tagged v4.0.0 (breaking changes under semver). Verified end-to-end by packing and consuming it as a real NuGet package from Eggnine.Common.Tests, not just a project reference.

