### PR TITLE
MassDeq<T>: fix enumeration/dequeue order mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,56 @@
 
 Format loosely follows [Keep a Changelog](https://keepachangelog.com/). Versions follow SemVer.
 
+## 5.0.0 - 2026-07-08
+
+### Fixed
+
+- **`MassDeq<T>` enumeration order didn't match dequeue order.** `Enqueue` prepended at `_head`,
+  and `GetEnumerator`/`GetLiveEnumerator` also started from `_head` — meaning enumeration (and
+  therefore `foreach`, `.ToList()`, `.First()`, `ICollection<T>.Remove`, `Contains`, `CopyTo`)
+  yielded items newest-first, the *opposite* of what `TryDequeue` would actually remove first.
+  Found while tracing a real bug in a consumer (`GameEngineQueue.RiffConsumeLoopAsync`) that
+  assumed `.First()` meant "the oldest item," matching `System.Collections.Generic.Queue<T>`
+  convention — it didn't. Root cause was one direction mismatch between insertion and
+  enumeration; traced through by hand to confirm `TryDequeue`/`TryPeek` were already internally
+  consistent with each other (both already used `_tail`), so the fix only ever touched which
+  physical end insertion and enumeration point at, not the linked-list splicing itself.
+- **`TryMassDequeue`'s returned segment had its own head/tail swapped** relative to the
+  now-corrected head-is-front convention — surfaced only once enumeration order itself was fixed
+  and re-verified by hand.
+- **`CopyTo` composed `CloneReverse` + front-removal**, which happened to produce
+  enumeration-order output only because enumeration order itself was backwards; fixed to compose
+  `Clone` + `TryDequeueHead`, matching the corrected convention.
+- Typo in `MassDeqEnumerator.Remove()`'s exception message ("Cannont" → "Cannot").
+
+### Changed
+
+- **Breaking, and a bigger API reshape than the fix above required on its own**: replaced the
+  implicit BCL-`Queue<T>`-style convention (`Enqueue`/`TryDequeue`/`TryPeek` silently default to
+  one physical end each, and used to be swappable instance-wide via `Reverse()`/`IsReversed`)
+  with a fully explicit head/tail API. Every insert/remove/peek operation now names the physical
+  end it acts on: `EnqueueHead`/`EnqueueTail`, `TryDequeueHead`/`DequeueHead`/`TryDequeueTail`/
+  `DequeueTail`, `TryPeekHead`/`PeekHead`/`TryPeekTail`/`PeekTail`. All are O(1), matching the
+  structure's actual capability at either end (previously only exposed at one end each).
+  `Add(T)` now calls `EnqueueTail` (append, matching `List<T>.Add`-style semantics).
+- **Breaking**: removed `IsReversed`/`Reverse()` entirely, from both `MassDeq<T>` and
+  `IMassDeq<T>`. With every member now explicit about which physical end it targets, an
+  instance-wide "reversed" toggle had no remaining job except enumeration direction — and that's
+  now served by the new `GetReversedEnumerator()` (see below) without any mutable per-instance
+  state to reason about.
+- **Breaking**: `Clone`/`CloneReverse` are no longer composed as `CloneReverse(...).Reverse()` —
+  standalone implementations now that `Reverse()` is gone. `Clone` walks head-to-tail and calls
+  `EnqueueTail` (faithful copy); `CloneReverse` walks head-to-tail and calls `EnqueueHead`
+  (genuinely reversed copy) — behavior is unchanged, just no longer dependent on the removed
+  method.
+
+### Added
+
+- `GetReversedEnumerator()` on the concrete `MassDeq<T>` — a detached snapshot enumerator, same
+  safety guarantees as `GetEnumerator()`, walking tail-to-head instead of head-to-tail. Not added
+  to `IMassDeq<T>`, matching `GetEnumerator()`'s own precedent of being a concrete-type-only
+  member (the interface only ever exposed the boxed `IEnumerable<T>.GetEnumerator()`).
+
 ## 4.0.0 - 2026-07-07
 
 ### Fixed

--- a/Collections/IMassDeq.cs
+++ b/Collections/IMassDeq.cs
@@ -8,7 +8,7 @@ namespace Eggnine.Common.Collections;
 
 /// <summary>
 /// Members <see cref="MassDeq{T}"/> offers beyond the standard <see cref="ICollection{T}"/> surface:
-/// head-side insertion, contiguous mass-dequeue, predicate-based splicing, cloning, and a read-only
+/// tail-side insertion, contiguous mass-dequeue, predicate-based splicing, cloning, and a read-only
 /// view. Also declares <see cref="IReadOnlyCollection{T}"/> since <see cref="MassDeq{T}"/> already
 /// satisfies it structurally (via <see cref="ICollection{T}.Count"/> and its enumerator) — callers
 /// that only need read access can accept <see cref="IMassDeq{T}"/> directly without going through
@@ -16,34 +16,46 @@ namespace Eggnine.Common.Collections;
 /// </summary>
 public interface IMassDeq<T> : ICollection<T>, IReadOnlyCollection<T>
 {
-    /// <summary>True if the deque is currently walking head-to-tail in reverse (see <see cref="Reverse"/>).</summary>
-    bool IsReversed { get; }
+    /// <summary>Insert at the head (front). O(1).</summary>
+    void EnqueueHead(T item);
 
-    /// <summary>Flips which end Enqueue/TryDequeue/enumeration treat as head. O(1).</summary>
-    void Reverse();
+    /// <summary>Insert at the tail (back). O(1).</summary>
+    void EnqueueTail(T item);
 
-    /// <summary>Prepend at head. O(1).</summary>
-    void Enqueue(T item);
+    /// <summary>Removes a single item from the head (front) in O(1) time. Returns false if the deque is empty.</summary>
+    bool TryDequeueHead(out T item);
 
-    /// <summary>Removes a single item from the tail in O(1) time. Returns false if the deque is empty.</summary>
-    bool TryDequeue(out T item);
-
-    /// <summary>Same as <see cref="TryDequeue"/> but throws <see cref="InvalidOperationException"/>
+    /// <summary>Same as <see cref="TryDequeueHead"/> but throws <see cref="InvalidOperationException"/>
     /// instead of returning false when the deque is empty — matches <see cref="Queue{T}.Dequeue"/>.</summary>
-    T Dequeue();
+    T DequeueHead();
 
-    /// <summary>Looks at the next item <see cref="Dequeue"/>/<see cref="TryDequeue"/> would return,
+    /// <summary>Removes a single item from the tail (back) in O(1) time. Returns false if the deque is empty.</summary>
+    bool TryDequeueTail(out T item);
+
+    /// <summary>Same as <see cref="TryDequeueTail"/> but throws <see cref="InvalidOperationException"/>
+    /// instead of returning false when the deque is empty.</summary>
+    T DequeueTail();
+
+    /// <summary>Looks at the item <see cref="DequeueHead"/>/<see cref="TryDequeueHead"/> would return,
     /// without removing it. Returns false if the deque is empty.</summary>
-    bool TryPeek(out T item);
+    bool TryPeekHead(out T item);
 
-    /// <summary>Same as <see cref="TryPeek"/> but throws <see cref="InvalidOperationException"/>
+    /// <summary>Same as <see cref="TryPeekHead"/> but throws <see cref="InvalidOperationException"/>
     /// instead of returning false when the deque is empty — matches <see cref="Queue{T}.Peek"/>.</summary>
-    T Peek();
+    T PeekHead();
+
+    /// <summary>Looks at the item <see cref="DequeueTail"/>/<see cref="TryDequeueTail"/> would return,
+    /// without removing it. Returns false if the deque is empty.</summary>
+    bool TryPeekTail(out T item);
+
+    /// <summary>Same as <see cref="TryPeekTail"/> but throws <see cref="InvalidOperationException"/>
+    /// instead of returning false when the deque is empty.</summary>
+    T PeekTail();
 
     /// <summary>
-    /// Detaches a contiguous run starting from the tail (or head, if <see cref="IsReversed"/>) for as
-    /// long as <paramref name="predicate"/> holds, returning it as a new deque. Returns false, leaving
-    /// this deque untouched, if empty or the boundary item doesn't match.
+    /// Detaches a contiguous run starting from the head, for as long as <paramref name="predicate"/>
+    /// holds, returning it as a new deque. Returns false, leaving this deque untouched, if empty
+    /// or the boundary item doesn't match.
     /// </summary>
     bool TryMassDequeue(Predicate<T> predicate, out IMassDeq<T> segment);
 

--- a/Collections/MassDeq.cs
+++ b/Collections/MassDeq.cs
@@ -9,13 +9,21 @@ using System.Threading;
 namespace Eggnine.Common.Collections;
 
 /// <summary>
-/// Doubly-linked deque with O(1) Enqueue (head) and O(1) TryMassDequeue: enumerates until
-/// predicate(current.Value) is false, then splits. <c>foreach</c> (via the public
-/// <see cref="GetEnumerator"/>) takes a detached snapshot under one lock acquisition, so it is
-/// safe to enumerate concurrently with mutation from other threads: O(n) with one lock hold and
-/// one copy. The class's own splicing operations (<see cref="Contains"/>, <see cref="TryRemove"/>,
-/// <see cref="InsertBefore"/>, <see cref="CloneReverse"/>) walk the live list directly under the
-/// same lock instead, avoiding that copy since they never release the lock mid-walk.
+/// Doubly-linked deque with O(1) operations at either end and O(1) TryMassDequeue: enumerates
+/// until predicate(current.Value) is false, then splits. Every member names the physical end it
+/// operates on explicitly (<see cref="EnqueueHead"/>/<see cref="EnqueueTail"/>,
+/// <see cref="TryDequeueHead"/>/<see cref="TryDequeueTail"/>, <see cref="TryPeekHead"/>/
+/// <see cref="TryPeekTail"/>) rather than relying on a BCL-Queue-style implicit convention —
+/// nothing here is a "front" or "back" you have to remember, it's always literally the head or
+/// the tail. Enumeration (via <c>foreach</c>/<see cref="GetEnumerator"/>) always walks head to
+/// tail; <see cref="GetReversedEnumerator"/> walks the other direction for callers that
+/// specifically need that, without any mutable per-instance "reversed" state to reason about.
+/// <c>foreach</c>/<see cref="GetEnumerator"/>/<see cref="GetReversedEnumerator"/> all take a
+/// detached snapshot under one lock acquisition, so it is safe to enumerate concurrently with
+/// mutation from other threads: O(n) with one lock hold and one copy. The class's own splicing
+/// operations (<see cref="Contains"/>, <see cref="TryRemove"/>, <see cref="InsertBefore"/>,
+/// <see cref="CloneReverse"/>) walk the live list directly under the same lock instead, avoiding
+/// that copy since they never release the lock mid-walk.
 /// </summary>
 public sealed class MassDeq<T> : IMassDeq<T>
 {
@@ -35,23 +43,12 @@ public sealed class MassDeq<T> : IMassDeq<T>
     internal MassDeqNode<T>? _head;
     internal MassDeqNode<T>? _tail;
     internal int _count;
-    internal bool _isReversed;
     public int Count => Volatile.Read(ref _count);
-
-    public bool IsReversed => _isReversed;
 
     public bool IsReadOnly => false;
 
-    public void Reverse()
-    {
-        lock (_gate)
-        {
-            _isReversed = !_isReversed;
-        }
-    }
-
-    /// <summary>Prepend at head. O(1).</summary>
-    public void Enqueue(T item)
+    /// <summary>Insert at the head (front). O(1).</summary>
+    public void EnqueueHead(T item)
     {
         MassDeqNode<T> node = new(item);
         lock (_gate)
@@ -63,25 +60,38 @@ public sealed class MassDeq<T> : IMassDeq<T>
             }
             else
             {
-                if (_isReversed)
-                {
-                    node.Prev = _tail;
-                    _tail.Next = node;
-                    _tail = node;
-                }
-                else
-                {
-                    node.Next = _head;
-                    _head.Prev = node;
-                    _head = node;
-                }
+                node.Next = _head;
+                _head.Prev = node;
+                _head = node;
+            }
+            _count++;
+        }
+    }
+
+    /// <summary>Insert at the tail (back). O(1).</summary>
+    public void EnqueueTail(T item)
+    {
+        MassDeqNode<T> node = new(item);
+        lock (_gate)
+        {
+            if (_head is null || _tail is null)
+            {
+                _head = node;
+                _tail = node;
+            }
+            else
+            {
+                node.Prev = _tail;
+                _tail.Next = node;
+                _tail = node;
             }
             _count++;
         }
     }
 
     /// <summary>
-    /// Detach until predicate returns false or entire list.
+    /// Detach a contiguous run starting from the head, for as long as
+    /// <paramref name="predicate"/> holds, returning it as a new deque.
     /// **ONLY RETURNS CONTIGUOUS SEGMENTS**
     /// If empty, returns false.
     /// </summary>
@@ -95,45 +105,36 @@ public sealed class MassDeq<T> : IMassDeq<T>
             {
                 return false;
             }
-            if (!predicate(_isReversed ? _head.Value : _tail.Value))
+            if (!predicate(_head.Value))
             {
                 return false;
             }
-            current = _isReversed ? _head : _tail;
-            MassDeqNode<T> headTail = current;
+            current = _head;
+            MassDeqNode<T> originalHead = current;
             for (int newCount = 1; current is not null; newCount++)
             {
-                MassDeqNode<T>? nextPrev = _isReversed ? current.Next : current.Prev;
-                if (nextPrev is null)
+                MassDeqNode<T>? next = current.Next;
+                if (next is null)
                 {
-                    segment = new(current, headTail, _count)
-                    {
-                        _isReversed = _isReversed
-                    };
+                    // Entire list matched.
+                    segment = new(originalHead, current, _count);
                     _head = null;
                     _tail = null;
                     _count = 0;
                     return true;
                 }
-                if (predicate(nextPrev.Value))
+                if (predicate(next.Value))
                 {
-                    current = nextPrev;
+                    current = next;
                 }
                 else
                 {
-                    segment = new(current, headTail, newCount);
-                    if (_isReversed)
-                    {
-                        nextPrev.Prev = null;
-                        _head = current.Next;
-                        current.Next = null;
-                    }
-                    else
-                    {
-                        nextPrev.Next = null;
-                        _tail = current.Prev;
-                        current.Prev = null;
-                    }
+                    // segment spans [originalHead .. current] — head-to-tail order preserved,
+                    // matching this deque's own head-is-front convention.
+                    segment = new(originalHead, current, newCount);
+                    next.Prev = null;
+                    _head = next;
+                    current.Next = null;
                     _count -= newCount;
                     return true;
                 }
@@ -164,13 +165,27 @@ public sealed class MassDeq<T> : IMassDeq<T>
         }
     }
 
+    /// <summary>Faithful copy — same head-to-tail order as this deque.</summary>
     public MassDeq<T> Clone(Predicate<T>? wherePredicate = null)
     {
-        MassDeq<T> toReturn = CloneReverse(wherePredicate);
-        toReturn.Reverse();
+        MassDeq<T> toReturn = new();
+        lock (_gate)
+        {
+            for (MassDeqEnumerator<T> enumerator = GetLiveEnumerator(); enumerator.MoveNext();)
+            {
+                T value = enumerator.Current;
+                if (wherePredicate == null || wherePredicate(value))
+                {
+                    toReturn.EnqueueTail(value);
+                }
+            }
+        }
         return toReturn;
     }
 
+    /// <summary>Same as <see cref="Clone"/> but the copy comes out in reverse (tail-to-head)
+    /// order — walks this deque head-to-tail once, prepending each match, so the last item
+    /// visited (this deque's own tail) ends up at the clone's head.</summary>
     public MassDeq<T> CloneReverse(Predicate<T>? wherePredicate = null)
     {
         MassDeq<T> toReturn = new();
@@ -179,9 +194,9 @@ public sealed class MassDeq<T> : IMassDeq<T>
             for (MassDeqEnumerator<T> enumerator = GetLiveEnumerator(); enumerator.MoveNext();)
             {
                 T value = enumerator.Current;
-                if (wherePredicate == null ? true : wherePredicate(value))
+                if (wherePredicate == null || wherePredicate(value))
                 {
-                    toReturn.Enqueue(value);
+                    toReturn.EnqueueHead(value);
                 }
             }
         }
@@ -194,10 +209,10 @@ public sealed class MassDeq<T> : IMassDeq<T>
     }
 
     /// <summary>
-    /// Removes a single item from the tail in O(1) time.
+    /// Removes a single item from the head (front) in O(1) time.
     /// Returns false if the deque is empty.
     /// </summary>
-    public bool TryDequeue(out T item)
+    public bool TryDequeueHead(out T item)
     {
         lock (_gate)
         {
@@ -207,10 +222,10 @@ public sealed class MassDeq<T> : IMassDeq<T>
                 return false;
             }
 
-            MassDeqNode<T> node = _isReversed ? _head : _tail;
+            MassDeqNode<T> node = _head;
             item = node.Value;
 
-            if ((_isReversed ? node.Next : node.Prev) is null)
+            if (node.Next is null)
             {
                 // Only one element in the deque.
                 _head = null;
@@ -218,19 +233,43 @@ public sealed class MassDeq<T> : IMassDeq<T>
             }
             else
             {
-                // Detach the head or tail node.
-                if (_isReversed)
-                {
-                    _head = node.Next;
-                    _head!.Prev = null;
-                    node.Next = null;
-                }
-                else
-                {
-                    _tail = node.Prev;
-                    _tail!.Next = null;
-                    node.Prev = null;
-                }
+                _head = node.Next;
+                _head.Prev = null;
+                node.Next = null;
+            }
+            _count--;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Removes a single item from the tail (back) in O(1) time.
+    /// Returns false if the deque is empty.
+    /// </summary>
+    public bool TryDequeueTail(out T item)
+    {
+        lock (_gate)
+        {
+            if (_tail is null || _head is null)
+            {
+                item = default!;
+                return false;
+            }
+
+            MassDeqNode<T> node = _tail;
+            item = node.Value;
+
+            if (node.Prev is null)
+            {
+                // Only one element in the deque.
+                _head = null;
+                _tail = null;
+            }
+            else
+            {
+                _tail = node.Prev;
+                _tail.Next = null;
+                node.Prev = null;
             }
             _count--;
             return true;
@@ -239,12 +278,13 @@ public sealed class MassDeq<T> : IMassDeq<T>
 
 
     /// <summary>
-    /// Returns a detached, immutable snapshot enumerator, what <c>foreach</c> binds to. Safe to
-    /// walk concurrently with mutation on the live deque: the snapshot is copied under one
-    /// <see cref="_gate"/> acquisition before this method returns, so nothing the caller does
-    /// afterward can observe a concurrent Enqueue/TryDequeue/TryRemove. Calling
-    /// <see cref="MassDeqEnumerator{T}.InsertBefore"/> or <see cref="MassDeqEnumerator{T}.Remove"/>
-    /// on the result throws, since there is no live list underneath it to splice into.
+    /// Returns a detached, immutable snapshot enumerator, what <c>foreach</c> binds to. Walks
+    /// head to tail. Safe to walk concurrently with mutation on the live deque: the snapshot is
+    /// copied under one <see cref="_gate"/> acquisition before this method returns, so nothing
+    /// the caller does afterward can observe a concurrent EnqueueHead/EnqueueTail/TryDequeueHead/
+    /// TryDequeueTail/TryRemove. Calling <see cref="MassDeqEnumerator{T}.InsertBefore"/> or
+    /// <see cref="MassDeqEnumerator{T}.Remove"/> on the result throws, since there is no live list
+    /// underneath it to splice into.
     /// </summary>
     public MassDeqEnumerator<T> GetEnumerator()
     {
@@ -252,7 +292,7 @@ public sealed class MassDeq<T> : IMassDeq<T>
         {
             MassDeqNode<T>? snapshotHead = null;
             MassDeqNode<T>? snapshotTail = null;
-            MassDeqNode<T>? source = _isReversed ? _tail : _head;
+            MassDeqNode<T>? source = _head;
             while (source is not null)
             {
                 MassDeqNode<T> copy = new(source.Value);
@@ -266,7 +306,39 @@ public sealed class MassDeq<T> : IMassDeq<T>
                     copy.Prev = snapshotTail;
                 }
                 snapshotTail = copy;
-                source = _isReversed ? source.Prev : source.Next;
+                source = source.Next;
+            }
+            return new MassDeqEnumerator<T>(this, snapshotHead, isReversed: false, isSnapshot: true);
+        }
+    }
+
+    /// <summary>
+    /// Same as <see cref="GetEnumerator"/> but walks tail to head instead — for callers with a
+    /// specific need to consume the deque back-to-front without physically reversing it or
+    /// paying for a <see cref="CloneReverse"/>. A detached snapshot, same safety guarantees as
+    /// <see cref="GetEnumerator"/>.
+    /// </summary>
+    public MassDeqEnumerator<T> GetReversedEnumerator()
+    {
+        lock (_gate)
+        {
+            MassDeqNode<T>? snapshotHead = null;
+            MassDeqNode<T>? snapshotTail = null;
+            MassDeqNode<T>? source = _tail;
+            while (source is not null)
+            {
+                MassDeqNode<T> copy = new(source.Value);
+                if (snapshotTail is null)
+                {
+                    snapshotHead = copy;
+                }
+                else
+                {
+                    snapshotTail.Next = copy;
+                    copy.Prev = snapshotTail;
+                }
+                snapshotTail = copy;
+                source = source.Prev;
             }
             return new MassDeqEnumerator<T>(this, snapshotHead, isReversed: false, isSnapshot: true);
         }
@@ -275,13 +347,13 @@ public sealed class MassDeq<T> : IMassDeq<T>
     /// <summary>
     /// Returns an enumerator over the live list, for the class's own splicing operations
     /// (<see cref="Contains"/>, <see cref="TryRemove"/>, <see cref="InsertBefore"/>,
-    /// <see cref="CloneReverse"/>) to walk under a lock they already hold, without paying for a
-    /// snapshot copy they'd immediately discard. Not safe to use outside a <see cref="_gate"/>
-    /// hold, hence internal rather than public.
+    /// <see cref="Clone"/>, <see cref="CloneReverse"/>) to walk under a lock they already hold,
+    /// without paying for a snapshot copy they'd immediately discard. Always walks head to tail —
+    /// not safe to use outside a <see cref="_gate"/> hold, hence internal rather than public.
     /// </summary>
     internal MassDeqEnumerator<T> GetLiveEnumerator()
     {
-        return new MassDeqEnumerator<T>(this, _isReversed ? _tail : _head, _isReversed);
+        return new MassDeqEnumerator<T>(this, _head, isReversed: false);
     }
 
     IEnumerator<T> IEnumerable<T>.GetEnumerator()
@@ -295,7 +367,7 @@ public sealed class MassDeq<T> : IMassDeq<T>
 
     public void Add(T item)
     {
-        Enqueue(item);
+        EnqueueTail(item);
     }
 
     public void Clear()
@@ -305,7 +377,6 @@ public sealed class MassDeq<T> : IMassDeq<T>
             _head = null;
             _tail = null;
             _count = 0;
-            _isReversed = false;
         }
         return;
     }
@@ -335,7 +406,7 @@ public sealed class MassDeq<T> : IMassDeq<T>
 
     public void CopyTo(T[] array, int arrayIndex)
     {
-        MassDeq<T> reverseClone;
+        MassDeq<T> clone;
         lock (_gate)
         {
             if (array is null)
@@ -350,10 +421,10 @@ public sealed class MassDeq<T> : IMassDeq<T>
             {
                 throw new ArgumentException("The number of elements in the source MassDeq is greater than the available space from arrayIndex to the end of the destination array.");
             }
-            reverseClone = CloneReverse();
+            clone = Clone();
         }
         T t = default!;
-        while (arrayIndex < array.Length && reverseClone.TryDequeue(out t))
+        while (arrayIndex < array.Length && clone.TryDequeueHead(out t))
         {
             array[arrayIndex++] = t;
         }
@@ -361,8 +432,9 @@ public sealed class MassDeq<T> : IMassDeq<T>
 
     bool ICollection<T>.Remove(T item) => TryRemove(item, out _);
 
-    /// <summary>Removes the first item equal to <paramref name="item"/>. Returns false, leaving
-    /// <paramref name="removed"/> default, if nothing matched.</summary>
+    /// <summary>Removes the first item equal to <paramref name="item"/>, in head-to-tail
+    /// (enumeration) order. Returns false, leaving <paramref name="removed"/> default, if nothing
+    /// matched.</summary>
     public bool TryRemove(T item, out T? removed)
     {
         lock (_gate)
@@ -381,13 +453,13 @@ public sealed class MassDeq<T> : IMassDeq<T>
         }
     }
 
-    /// <summary>Looks at the next item <see cref="Dequeue"/>/<see cref="TryDequeue"/> would return,
-    /// without removing it. Returns false if the deque is empty.</summary>
-    public bool TryPeek(out T item)
+    /// <summary>Looks at the item <see cref="DequeueHead"/>/<see cref="TryDequeueHead"/> would
+    /// return, without removing it. Returns false if the deque is empty.</summary>
+    public bool TryPeekHead(out T item)
     {
         lock (_gate)
         {
-            MassDeqNode<T>? node = _isReversed ? _head : _tail;
+            MassDeqNode<T>? node = _head;
             if (node is null)
             {
                 item = default!;
@@ -398,22 +470,61 @@ public sealed class MassDeq<T> : IMassDeq<T>
         }
     }
 
-    /// <summary>Same as <see cref="TryPeek"/> but throws <see cref="InvalidOperationException"/>
-    /// instead of returning false when the deque is empty — matches <see cref="Queue{T}.Peek"/>.</summary>
-    public T Peek()
+    /// <summary>Looks at the item <see cref="DequeueTail"/>/<see cref="TryDequeueTail"/> would
+    /// return, without removing it. Returns false if the deque is empty.</summary>
+    public bool TryPeekTail(out T item)
     {
-        if (!TryPeek(out T item))
+        lock (_gate)
+        {
+            MassDeqNode<T>? node = _tail;
+            if (node is null)
+            {
+                item = default!;
+                return false;
+            }
+            item = node.Value;
+            return true;
+        }
+    }
+
+    /// <summary>Same as <see cref="TryPeekHead"/> but throws <see cref="InvalidOperationException"/>
+    /// instead of returning false when the deque is empty — matches <see cref="Queue{T}.Peek"/>.</summary>
+    public T PeekHead()
+    {
+        if (!TryPeekHead(out T item))
         {
             throw new InvalidOperationException("MassDeq is empty.");
         }
         return item;
     }
 
-    /// <summary>Same as <see cref="TryDequeue"/> but throws <see cref="InvalidOperationException"/>
-    /// instead of returning false when the deque is empty — matches <see cref="Queue{T}.Dequeue"/>.</summary>
-    public T Dequeue()
+    /// <summary>Same as <see cref="TryPeekTail"/> but throws <see cref="InvalidOperationException"/>
+    /// instead of returning false when the deque is empty.</summary>
+    public T PeekTail()
     {
-        if (!TryDequeue(out T item))
+        if (!TryPeekTail(out T item))
+        {
+            throw new InvalidOperationException("MassDeq is empty.");
+        }
+        return item;
+    }
+
+    /// <summary>Same as <see cref="TryDequeueHead"/> but throws <see cref="InvalidOperationException"/>
+    /// instead of returning false when the deque is empty — matches <see cref="Queue{T}.Dequeue"/>.</summary>
+    public T DequeueHead()
+    {
+        if (!TryDequeueHead(out T item))
+        {
+            throw new InvalidOperationException("MassDeq is empty.");
+        }
+        return item;
+    }
+
+    /// <summary>Same as <see cref="TryDequeueTail"/> but throws <see cref="InvalidOperationException"/>
+    /// instead of returning false when the deque is empty.</summary>
+    public T DequeueTail()
+    {
+        if (!TryDequeueTail(out T item))
         {
             throw new InvalidOperationException("MassDeq is empty.");
         }

--- a/Collections/MassDeqEnumerator.cs
+++ b/Collections/MassDeqEnumerator.cs
@@ -114,7 +114,7 @@ public struct MassDeqEnumerator<T> : IEnumerator<T>
         }
         if (_current is null)
         {
-            throw new InvalidOperationException("Cannont remove current before moveNext or after end of enumerable");
+            throw new InvalidOperationException("Cannot remove current before moveNext or after end of enumerable");
         }
         lock (_original._gate)
         {

--- a/Eggnine.Common.csproj
+++ b/Eggnine.Common.csproj
@@ -7,7 +7,7 @@
     <PackageProjectUrl>https://github.com/rf-eggnine/Eggnine.Common</PackageProjectUrl>
     <RepositoryUrl>https://github.com/rf-eggnine/Eggnine.Common</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>4.0.0</Version>
+    <Version>5.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Replace implicit convention with explicit head/tail API

Enqueue prepended at _head while GetEnumerator/GetLiveEnumerator also started from _head, so enumeration (foreach, .ToList(), .First(), ICollection<T>.Remove, Contains, CopyTo) yielded items newest-first -- the opposite of what TryDequeue would actually remove first. Found while tracing a real bug in a consumer (GameEngineQueue.RiffConsumeLoopAsync) that assumed .First() meant "the oldest item," matching System.Collections.Generic.Queue<T> convention -- it didn't.

Rather than just flip the enumeration direction, replaced the implicit BCL-Queue-style convention (Enqueue/TryDequeue/TryPeek silently default to one end each, swappable instance-wide via Reverse()/IsReversed) with a fully explicit head/tail API: EnqueueHead/EnqueueTail, TryDequeueHead/DequeueHead/ TryDequeueTail/DequeueTail, TryPeekHead/PeekHead/TryPeekTail/PeekTail. Every member now names the physical end it acts on, all still O(1) -- previously only one end was exposed for insertion and one for removal, despite the doubly-linked structure supporting O(1) operations at either end.

IsReversed/Reverse() are gone entirely -- with every member explicit about its end, an instance-wide toggle had no remaining job except enumeration direction, which is now served by the new GetReversedEnumerator() (concrete MassDeq<T> only, matching GetEnumerator()'s own precedent of not being on IMassDeq<T>) without any mutable per-instance state to reason about.

Also fixed while re-deriving the corrected direction by hand: TryMassDequeue's returned segment had its head/tail constructor args swapped relative to the corrected convention, and CopyTo composed CloneReverse + front-removal in a way that only happened to work under the old (backwards) enumeration order -- switched to Clone + TryDequeueHead. Clone/CloneReverse no longer compose via the removed Reverse(); both have standalone implementations now. Fixed a typo in MassDeqEnumerator.Remove()'s exception message along the way.

Version bump only in this commit -- no tag yet. Existing tests in Eggnine.Common.Tests still target the pre-rewrite API/order and need a follow-up pass before this is tagged.


Claude-Session: https://claude.ai/code/session_01WNe4G3ya89Fh9psXij43Kk